### PR TITLE
Allow `mc-events` post type to be searchable

### DIFF
--- a/src/my-calendar-core.php
+++ b/src/my-calendar-core.php
@@ -1542,7 +1542,7 @@ function mc_post_type() {
 	$arguments = array(
 		'public'              => apply_filters( 'mc_event_posts_public', true ),
 		'publicly_queryable'  => true,
-		'exclude_from_search' => true,
+		'exclude_from_search' => apply_filters( 'mc_event_exclude_from_search', true ),
 		'show_ui'             => true,
 		'show_in_menu'        => apply_filters( 'mc_show_custom_posts_in_menu', false ),
 		'menu_icon'           => null,

--- a/src/my-calendar-core.php
+++ b/src/my-calendar-core.php
@@ -1542,6 +1542,9 @@ function mc_post_type() {
 	$arguments = array(
 		'public'              => apply_filters( 'mc_event_posts_public', true ),
 		'publicly_queryable'  => true,
+		// WARNING: Allowing the post type to be searchable will not provide a true event search, especially with respect to recurring events. 
+		// It will not search recurring events by date, only the post content from each event. Enable only if requirements for search 
+		// are limited to post content. Details: https://github.com/joedolson/my-calendar/issues/23 
 		'exclude_from_search' => apply_filters( 'mc_event_exclude_from_search', true ),
 		'show_ui'             => true,
 		'show_in_menu'        => apply_filters( 'mc_show_custom_posts_in_menu', false ),


### PR DESCRIPTION
allow exclude_from_search post type registration to be modified with a filter

closes #23 