### PR TITLE
Update my-calendar-event-editor.php

### DIFF
--- a/src/my-calendar-event-editor.php
+++ b/src/my-calendar-event-editor.php
@@ -181,6 +181,9 @@ function mc_add_post_meta_data( $post_id, $post, $data, $event_id ) {
 	}
 	update_post_meta( $post_id, '_mc_event_desc', $description );
 	update_post_meta( $post_id, '_mc_event_image', $image );
+	//Nice date for event Calendar
+	update_post_meta( $post_id, '_mc_nice_date', date("d.m.",strtotime( $event_date )) );
+
 	// This is only used by My Tickets, so only the first date occurrence is required.
 	if ( isset( $data['event_begin'] ) ) {
 		$event_date = ( is_array( $data['event_begin'] ) ) ? $data['event_begin'][0] : $data['event_begin'];


### PR DESCRIPTION
I propose to set a need a nice formatted date to use in non my-calendar output like essential grid

<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
<!-- Please describe your changes -->
Added 1 line to add a nice formatted date to use in other plugins (like essntial grid)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Minimal change, added to our produtive environment, run without issues for over a week

<!-- Include details of your testing environment, tests ran to see how -->
https://tsc-passau.de
<!-- your change affects other areas of the code, etc. -->
no

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->+
add a meta with a better formatted date - to use it in external componente (in this case essential grid), but I am sure it may help in other components as ell
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
add meta for Date in other components
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [ ] My code follows the WordPress coding standards.
- [x] My code has proper inline documentation.
