### PR TITLE
bugfix: Category name by using multibyte language.

### DIFF
--- a/src/my-calendar-categories.php
+++ b/src/my-calendar-categories.php
@@ -1488,5 +1488,5 @@ function mc_category_class( $object, $prefix ) {
 		$fallback = 'category_slug_missing';
 	}
 
-	return $prefix . strtolower( sanitize_html_class( str_replace( ' ', '-', $name ), $prefix . $fallback ) );
+	return $prefix . strtolower( sanitize_html_class( str_replace( ' ', '-', $id ), $prefix . $fallback ) );
 }


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
Category name by using multibyte language, Calendar category classes are not display.
So I changed mc_category_class function just to use category id, not category name.

## How Has This Been Tested?
I searched the place where mc_category_class function is used and checked that change is not fatal effect.
And I checked in my site, category classification  color works correctly and category class display correctly.

## Screenshots (jpeg or gifs if applicable):
![スクリーンショット 2023-02-03 114544](https://user-images.githubusercontent.com/16435468/216500426-c6591d76-0ffd-496c-afd1-610430161848.png)


## Types of changes
 Bug fix (non-breaking change which fixes an issue)
 
## Checklist:
- [〇] My code is tested.
- [〇] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [〇 ] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
->too short to write inline documentation.
