### PR TITLE
bugfix : selecting categories current class

### DIFF
--- a/src/my-calendar-navigation.php
+++ b/src/my-calendar-navigation.php
@@ -382,7 +382,7 @@ function mc_category_key( $category, $id = '' ) {
 		$hex   = ( 0 !== strpos( $cat->category_color, '#' ) ) ? '#' : '';
 		$class = mc_category_class( $cat, '' );
 
-		$selected_categories = ( empty( $_GET['mcat'] ) ) ? array() : explode( ',', map_deep( $_GET['mcat'], 'absint' ) );
+		$selected_categories = ( empty( $_GET['mcat'] ) ) ? array() : explode( ',',  $_GET['mcat'] );
 
 		if ( in_array( $cat->category_id, $selected_categories, true ) || $category === $cat->category_id ) {
 			$selected_categories = array_diff( $selected_categories, array( $cat->category_id ) );


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
When a user use category filter and select two or more category, current class not work correctly.

This cause , 
At First : I think map_deep positon is wrong.
```
// my-lalendar-navigation.php line385
 explode( ',', map_deep( $_GET['mcat'], 'absint' ) ); 
```
　↓
```
map_deep( explode( ',', $_GET['mcat'] ), 'absint' );
```

but only that not fixed.
absint function is cause of bug.
because in line 387, compare strict. So when 2 or more category is selected, every time return false. 
```
// my-lalendar-navigation.php line387
if ( in_array( $cat->category_id, $selected_categories, true ) || $category === $cat->category_id ) {
```

So I just remove map_deep function.
```
// my-lalendar-navigation.php line385
$selected_categories = ( empty( $_GET['mcat'] ) ) ? array() : explode( ',',  $_GET['mcat'] );
```
If you mind, please change line 387 to not strict or cast $cat->category_id to integer.

## How Has This Been Tested?
I dumped variable value, and check that value is correct many time.
And check the website move correctly.

## Screenshots (jpeg or gifs if applicab
![スクリーンショット 2023-02-03 120719](https://user-images.githubusercontent.com/16435468/216503308-b26ed701-a523-418e-b93e-8d80cfc94404.jpg)
le):


## Types of changes
 Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [●] My code is tested.
- [●] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [●] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
