### PR TITLE
Add a  Yoast SEO Schema graph integration

### DIFF
--- a/src/my-calendar-core.php
+++ b/src/my-calendar-core.php
@@ -485,6 +485,7 @@ add_action( 'mc_print_view_head', 'mc_enqueue_calendar_print_styles' );
  * Publically written head styles & scripts
  */
 function mc_head() {
+	// If Yoast SEO is active, we don't need to output this schema.
 	if ( defined( 'WPSEO_VERSION' ) ) {
 		return;
 	}
@@ -509,7 +510,7 @@ function mc_head() {
 }
 
 /**
- * Filters the Schema output, adding in organization blocks.
+ * Filters the Yoast SEO Schema output, adding in graph blocks for Events and Location.
  *
  * @param array             $graph   The schema graph.
  * @param Meta_Tags_Context $context Context value object.

--- a/src/my-calendar-core.php
+++ b/src/my-calendar-core.php
@@ -486,7 +486,6 @@ add_action( 'mc_print_view_head', 'mc_enqueue_calendar_print_styles' );
  */
 function mc_head() {
 	if ( defined( 'WPSEO_VERSION' ) ) {
-		add_filter( 'wpseo_schema_graph', 'mc_add_yoast_schema', 10, 2 );
 		return;
 	}
 

--- a/src/my-calendar.php
+++ b/src/my-calendar.php
@@ -193,6 +193,7 @@ function mc_load_textdomain() {
 // Add actions.
 add_action( 'admin_menu', 'my_calendar_menu' );
 add_action( 'wp_head', 'mc_head' );
+add_filter( 'wpseo_schema_graph', 'mc_add_yoast_schema', 10, 2 );
 add_action( 'delete_user', 'mc_deal_with_deleted_user', 10, 2 );
 add_action( 'widgets_init', 'mc_register_widgets' );
 add_action( 'init', 'mc_add_feed' );


### PR DESCRIPTION
## Description
Removes the default Schema output from My Calendar and adds it to the Yoast SEO Schema graph.

> [!NOTE]  
> There is some code duplication between these functions. Ideally, I'd say you need a helper function to prevent that.

## How Has This Been Tested?
Tested on my own site. 

Suggestion for testing: 

* Install [Yoast Test Helper](https://wordpress.org/plugins/yoast-test-helper/)
* Enable Development mode (this makes the Yoast SEO Schema graph more readable)
* See that either the `Event` or `Location` is added to the Schema graph.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [x] My code follows the WordPress coding standards.
- [x] My code has proper inline documentation.
