### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for Clicky using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.eslintrc.json export-ignore
+/.github export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.nvmrc export-ignore
+phpcs.xml.dist export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+CONTRIBUTING.md export-ignore
+hookdoc-conf.json export-ignore
+phpstan.neon.dist export-ignore
+phpunit.xml.dist export-ignore
+/tests export-ignore
+.wp-env.json export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
## Description
Adding a `.gitattributes` file makes sure that zip downloads don't contain unnecessary files.

## Types of changes
Purely development.

