### PR TITLE
Fix: Made string translatable in my-calendar-shortcodes.php file

### DIFF
--- a/src/my-calendar-shortcodes.php
+++ b/src/my-calendar-shortcodes.php
@@ -581,7 +581,7 @@ function mc_calendar_generator_fields( $post, $callback_args ) {
 							'card'     => __( 'Card', 'my-calendar' ),
 							'mini'     => __( 'Mini', 'my-calendar' ),
 						);
-						$options         = '<option value="">' . esc_html( 'Default', 'my-calendar' ) . '</option>';
+						$options         = '<option value="">' . esc_html__( 'Default', 'my-calendar' ) . '</option>';
 						foreach ( $enabled_formats as $f ) {
 							$options .= '<option value="' . $f . '"' . selected( $f, $format ) . '>' . $format_labels[ $f ] . '</option>';
 						}


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
Fix: Made string translatable in my-calendar-shortcodes.php file

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fix: Made string translatable in my-calendar-shortcodes.php file

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [x] My code follows the WordPress coding standards.
- [ ] My code has proper inline documentation.
